### PR TITLE
Change packaging and Docker deployment strategy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,25 +35,9 @@ libraryDependencies ++= {
 
 parallelExecution in Test := false
 
+enablePlugins(JavaAppPackaging)
 enablePlugins(DockerPlugin)
-assemblyJarName in assembly := "s3mock.jar"
-mainClass in assembly := Some("io.findify.s3mock.Main")
-test in assembly := {}
 
-dockerfile in docker := new Dockerfile {
-  from("adoptopenjdk/openjdk11:jre-11.0.7_10-debian")
-  expose(8001)
-  add(assembly.value, "/app/s3mock.jar")
-  entryPoint(
-      "java", 
-      "-Xmx128m", 
-      "-jar", 
-      "--add-opens",
-      "java.base/jdk.internal.ref=ALL-UNNAMED",
-      "/app/s3mock.jar"
-  )
-}
-imageNames in docker := Seq(
-  ImageName(s"findify/s3mock:${version.value.replaceAll("\\+", "_")}"),
-  ImageName(s"findify/s3mock:latest")
-)
+dockerRepository := Some("io.github.marko-asplund")
+dockerBaseImage := "eclipse-temurin:11-jre"
+dockerExposedPorts := Seq(8001)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,5 +5,5 @@ addDependencyTreePlugin
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
+
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")


### PR DESCRIPTION
Switch from `sbt-assembly` + `sbt-docker` to using `sbt-native-packager`.
The former approach builds a fat jar that results in class file deduplication issues described in:
https://github.com/sbt/sbt-assembly/issues/391

`sbt-native-packager` is arguably a better approach among other things since it does not rely in building a fat jar.